### PR TITLE
Add ED64 Plus to Development Hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ A curated list of Nintendo 64 development resources including toolchains, docume
 * [sm64gameshark](https://sites.google.com/site/sm64gameshark/resources/transfering-codes-over-usb) - How to transfer GameShark codes from USB to parallel, and how to identify GameShark cartridges with functional parallel ports
 * [gs_libusb](https://github.com/hcs64/gs_libusb) - GameShark Pro utilities using libusb over a USB parallel port adapter
 * [Replacement Carts](https://n64preservationproject.com/) - A set of EagleCAD files for manufacturing your own N64 carts
+* [ED64 Plus](https://ed64p.com/) - A Chinese clone of the Everdrive 64 at a much cheaper price point. It also has a disconnected USB port with a missing FT245R chip that [can be reattached](https://odysee.com/@backofficeshow:f/everdrive-ed64-nintendo-64-teardown:0) for theoretical added functionality. 
 
 ## Tools and Libraries
 


### PR DESCRIPTION
* [ED64 Plus](https://ed64p.com/) - A Chinese clone of the Everdrive 64 at a much cheaper price point. It also has a disconnected USB port with a missing FT245R chip that [can be reattached](https://odysee.com/@backofficeshow:f/everdrive-ed64-nintendo-64-teardown:0) for theoretical added functionality

I am talking about the newer version of the flash cartridge as the older version is not relevant and I don't think its being sold anymore. the ED64 appears to have a lot of the same functionality as older Everdrive 64 cartridges with some other features mixed in, except it is at the much lower price point of $60-$80.

The USB port is non-functional but theoretically can be restored by soldering the USB chip back on. Unfortunately I could not find whether soldering the chip actually works. I will be getting one of these carts and eventually testing this myself and will report back with what I find.