### PR TITLE
Rust Examples points to 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ A curated list of Nintendo 64 development resources including toolchains, docume
 * [nust64](https://github.com/bigbass1997/nust64) - Rust crate for compiling a Rust project into an N64 ROM
 * [n64-systemtest](https://github.com/lemmy-64/n64-systemtest) - A collection of hardware tests written in Rust
 * [cargo-n64](https://github.com/rust-console/cargo-n64) - A `cargo` subcommand to build Nintendo 64 ROMs in Rust
-* [cargo-n64/examples](https://github.com/rust-console/cargo-n64/tree/master/examples) - Rust examples using cargo-n64
+* [cargo-n64/examples](https://github.com/rust-console/rrt0/tree/main/examples) - Rust examples using cargo-n64
 * [n64toolchain](https://github.com/monocasa/n64toolchain) - Rust Implementation of a Nintendo 64 ROM toolchain
 * [rs64-rt](https://github.com/monocasa/rs64-rt) - Minimal Rust startup / runtime for Nintendo 64
 * [rs64-periph](https://github.com/monocasa/rs64-periph) - Fairly raw N64 MMIO definitions


### PR DESCRIPTION
the examples are pointing to a different branch