### PR TITLE
Add Legend of Elya - nano-GPT neural network on N64

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,8 @@ A curated list of Nintendo 64 development resources including toolchains, docume
 * [BrewReality](https://github.com/SpookyIluha/BrewReality) - A 3D flight simulator tech demo built with `libdragon`, featuring 128x128 textures and dynamic sky and lighting
 * [CounterEmotion-Bar](https://github.com/SpookyIluha/CounterEmotion-Bar) - A Targem Games 3-Day GameJam 2025 entry built with `libdragon` and `tiny3d`
 
+* [Legend of Elya](https://github.com/Scottcjn/legend-of-elya-n64) - A 4-layer nano-GPT neural network (819K parameters) running natively on the N64's MIPS R4300i FPU, believed to be the first LLM on Nintendo 64 hardware
+
 ### Rust
 
 * [nust64](https://github.com/bigbass1997/nust64) - Rust crate for compiling a Rust project into an N64 ROM


### PR DESCRIPTION
## Addition

Adds **Legend of Elya** to the Example Code section — a 4-layer nano-GPT transformer (819K parameters) running natively on the Nintendo 64's MIPS R4300i FPU.

### Details
- **Parameters**: 819K across 4 transformer layers
- **Weights**: ~848KB (Q8 + f16 scales), fits in N64's 4MB RAM
- **Arithmetic**: Float32 on the R4300i hardware FPU (no softfloat)
- **Features**: Big-endian weight loading, Taylor series exp() (no libm), custom memory management
- **Output**: Generates English text on real N64 hardware

Believed to be the first neural network / language model running on Nintendo 64.

Repo: https://github.com/Scottcjn/legend-of-elya-n64