### PR TITLE
Add hash-bench-n64 to Programming/C/Example Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ A curated list of Nintendo 64 development resources including toolchains, docume
 * [CounterEmotion-Bar](https://github.com/SpookyIluha/CounterEmotion-Bar) - A Targem Games 3-Day GameJam 2025 entry built with `libdragon` and `tiny3d`
 
 * [Legend of Elya](https://github.com/Scottcjn/legend-of-elya-n64) - A 4-layer nano-GPT neural network (819K parameters) running natively on the N64's MIPS R4300i FPU, believed to be the first LLM on Nintendo 64 hardware
+* [hash-bench-n64](https://github.com/dmang-dev/hash-bench-n64) - Hash-algorithm benchmark ROM that times 32 cryptographic and non-cryptographic hashes (CRC, MD5, SHA-1, SHA-512, BLAKE2s, etc.) on the VR4300 and displays µs/iter and KB/s on screen, using `libdragon`
 
 ### Rust
 


### PR DESCRIPTION
## What this PR does

Adds a single entry to **Programming → C → Example Code** (per CONTRIBUTING.md's "add to bottom of relevant category"):

```markdown
* [hash-bench-n64](https://github.com/dmang-dev/hash-bench-n64) - Hash-algorithm benchmark ROM that times 32 cryptographic and non-cryptographic hashes (CRC, MD5, SHA-1, SHA-512, BLAKE2s, etc.) on the VR4300 and displays µs/iter and KB/s on screen, using `libdragon`
```

## Why "Example Code"

It sits naturally next to `n64zlibbench` (already in the section) — same shape, just more algorithms. The other entries here are similar self-contained libdragon-using demonstrations. Not a game (no fit elsewhere), not a toolchain or library, not reverse engineering.

## Project at a glance

- **Repo:** https://github.com/dmang-dev/hash-bench-n64
- **v1.0.0 release with prebuilt `.z64` (1 MiB padded):** https://github.com/dmang-dev/hash-bench-n64/releases/tag/v1.0.0
- **License:** MIT
- **Built with:** libdragon
- **Tested in:** Ares 1.x, mupen64plus, m64p

(The README has a documented compatibility note: Project64 < 4.x rejects libdragon's custom IPL3, so Ares is recommended for emulator users.)

## Checklist (per [CONTRIBUTING.md](https://github.com/command-tab/awesome-n64-development/blob/main/CONTRIBUTING.md))

- [x] In English
- [x] In a minimal working state (prebuilt ROM committed + downloadable from the v1.0.0 release)
- [x] Clear purpose (hash-algorithm performance benchmark on VR4300)
- [x] Documentation present (README explains every algorithm, build, run, controls, the SHA-512>SHA-256 finding)
- [x] Entry uses the existing section's bullet style (`*` not `-`, no trailing period)
- [x] Added to the bottom of an existing section

## Disclosure

I'm the author.
