### PR TITLE
Update Legend of Elya description (6.36M ternary transformer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ A curated list of Nintendo 64 development resources including toolchains, docume
 * [BrewReality](https://github.com/SpookyIluha/BrewReality) - A 3D flight simulator tech demo built with `libdragon`, featuring 128x128 textures and dynamic sky and lighting
 * [CounterEmotion-Bar](https://github.com/SpookyIluha/CounterEmotion-Bar) - A Targem Games 3-Day GameJam 2025 entry built with `libdragon` and `tiny3d`
 
-* [Legend of Elya](https://github.com/Scottcjn/legend-of-elya-n64) - A 4-layer nano-GPT neural network (819K parameters) running natively on the N64's MIPS R4300i FPU, believed to be the first LLM on Nintendo 64 hardware
+* [Legend of Elya](https://github.com/Scottcjn/legend-of-elya-n64) - A Zelda-style homebrew game whose AI NPCs run a 6.36M-parameter ternary transformer with byte-level inference on the VR4300 MIPS III CPU (1.23 tok/s scalar, 2.19 tok/s via an RSP overlay, measured under the ares emulator). Built with libdragon
 * [hash-bench-n64](https://github.com/dmang-dev/hash-bench-n64) - Hash-algorithm benchmark ROM that times 32 cryptographic and non-cryptographic hashes (CRC, MD5, SHA-1, SHA-512, BLAKE2s, etc.) on the VR4300 and displays µs/iter and KB/s on screen, using `libdragon`
 
 ### Rust


### PR DESCRIPTION
### What this changes

Updates the existing **Legend of Elya** entry, which was out of date. The project has grown from the original ~819K "nano-GPT" into a **6.36M-parameter ternary transformer**, and the current description also overstated the runtime environment.

Old:
> A 4-layer nano-GPT neural network (819K parameters) running natively on the N64's MIPS R4300i FPU, believed to be the first LLM on Nintendo 64 hardware

New (matches the repo's own measured figures):
> A Zelda-style homebrew game whose AI NPCs run a 6.36M-parameter ternary transformer with byte-level inference on the VR4300 MIPS III CPU (1.23 tok/s scalar, 2.19 tok/s via an RSP overlay, measured under the ares emulator). Built with libdragon

The numbers are the repo's measured results under the ares emulator (not on physical silicon), so I removed the unverified "first LLM on N64 hardware" claim.

### Disclosure
I'm the author (Elyan Labs / @Scottcjn) — correcting my own entry for accuracy.
